### PR TITLE
name: update to GetZZZ_DeprecatedClusterName() for 1.24

### DIFF
--- a/v2/context.go
+++ b/v2/context.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import "context"
+
+type key int
+
+const (
+	keyCluster key = iota
+)
+
+// WithCluster injects a cluster name into a context
+func WithCluster(ctx context.Context, cluster Name) context.Context {
+	return context.WithValue(ctx, keyCluster, cluster)
+}
+
+// ClusterFromContext extracts a cluster name from the context
+func ClusterFromContext(ctx context.Context) (Name, bool) {
+	s, ok := ctx.Value(keyCluster).(Name)
+	return s, ok
+}

--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/kcp-dev/logicalcluster/v2
+
+go 1.17

--- a/v2/name.go
+++ b/v2/name.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"encoding/json"
+	"path"
+	"regexp"
+	"strings"
+)
+
+// ClusterHeader set to "<lcluster>" on a request is an alternative to accessing the
+// cluster via /clusters/<lcluster>. With that the <lcluster> can be access via normal kube-like
+// /api and /apis endpoints.
+const ClusterHeader = "X-Kubernetes-Cluster"
+
+// Name is the name of a logical cluster. A logical cluster is
+// 1. a (part of) etcd prefix to store objects in that cluster
+// 2. a (part of) a http path which serves a Kubernetes-cluster-like API with
+//    discovery, OpenAPI and the actual API groups.
+// 3. a value in metadata.clusterName in objects from cross-workspace list/watches,
+//    which is used to identify the logical cluster.
+//
+// A logical cluster is a colon separated list of words. In other words, it is
+// like a path, but with colons instead of slashes.
+type Name struct {
+	value string
+}
+
+const separator = ":"
+
+var (
+	// Wildcard is the name indicating cross-workspace requests.
+	Wildcard = New("*")
+)
+
+// New returns a Name from a string.
+func New(value string) Name {
+	return Name{value}
+}
+
+// NewValidated returns a Name from a string and whether it is a valid logical cluster.
+// A valid logical cluster returns true on IsValid().
+func NewValidated(value string) (Name, bool) {
+	n := Name{value}
+	return n, n.IsValid()
+}
+
+// Empty returns true if the logical cluster value is unset.
+func (n Name) Empty() bool {
+	return n.value == ""
+}
+
+// Path returns a path segment for the logical cluster to access its API.
+func (n Name) Path() string {
+	return path.Join("/clusters", n.value)
+}
+
+// String returns the string representation of the logical cluster name.
+func (n Name) String() string {
+	return n.value
+}
+
+// Object is a local interface representation of the Kubernetes metav1.Object, to avoid dependencies on
+// k8s.io/apimachinery.
+type Object interface {
+	GetZZZ_DeprecatedClusterName() string
+}
+
+// From returns the logical cluster name for obj.
+func From(obj Object) Name {
+	return Name{obj.GetZZZ_DeprecatedClusterName()}
+}
+
+// Parent returns the parent logical cluster name of the given logical cluster name.
+func (n Name) Parent() (Name, bool) {
+	parent, _ := n.Split()
+	return parent, parent.value != ""
+}
+
+// Split splits logical cluster immediately following the final colon,
+// separating it into a parent logical cluster and name component.
+// If there is no colon in path, Split returns an empty logical cluster name
+// and name set to path.
+func (n Name) Split() (parent Name, name string) {
+	i := strings.LastIndex(n.value, separator)
+	if i < 0 {
+		return Name{}, n.value
+	}
+	return Name{n.value[:i]}, n.value[i+1:]
+}
+
+// Base returns the last component of the logical cluster name.
+func (n Name) Base() string {
+	_, name := n.Split()
+	return name
+}
+
+// Join joins a parent logical cluster name and a name component.
+func (n Name) Join(name string) Name {
+	if n.value == "" {
+		return Name{name}
+	}
+	return Name{n.value + separator + name}
+}
+
+func (n Name) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&n.value)
+}
+
+func (n *Name) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	n.value = s
+	return nil
+}
+
+func (n Name) HasPrefix(other Name) bool {
+	return strings.HasPrefix(n.value, other.value)
+}
+
+var lclusterRegExp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9](:[a-z][a-z0-9-]*[a-z0-9])*$`)
+
+// IsValid returns true if the name is a Wildcard or a colon separated list of words where each word
+// starts with a lower-case letter and contains only lower-case letters, digits and hyphens.
+func (n Name) IsValid() bool {
+	return n == Wildcard || lclusterRegExp.MatchString(n.value)
+}

--- a/v2/name_test.go
+++ b/v2/name_test.go
@@ -1,0 +1,115 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestName_Split(t *testing.T) {
+	tests := []struct {
+		cn     Name
+		parent Name
+		name   string
+	}{
+		{New(""), New(""), ""},
+		{New("foo"), New(""), "foo"},
+		{New("foo:bar"), New("foo"), "bar"},
+		{New("foo:bar:baz"), New("foo:bar"), "baz"},
+		{New("foo::baz"), New("foo:"), "baz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotParent, gotName := tt.cn.Split()
+			if gotParent != tt.parent {
+				t.Errorf("Split() gotParent = %v, want %v", gotParent, tt.parent)
+			}
+			if gotName != tt.name {
+				t.Errorf("Split() gotName = %v, want %v", gotName, tt.name)
+			}
+		})
+	}
+}
+
+func TestJSON(t *testing.T) {
+	type container struct {
+		Name Name `json:"name"`
+	}
+
+	initial := container{
+		Name: New("foo:bar"),
+	}
+
+	raw, err := json.Marshal(initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual, expected := string(raw), `{"name":"foo:bar"}`; actual != expected {
+		t.Fatalf("incorrect marshalled bytes, expected %s, got %s", expected, actual)
+	}
+
+	var final container
+	if err := json.Unmarshal(raw, &final); err != nil {
+		t.Fatal(err)
+	}
+	if actual, expected := initial.Name, final.Name; actual != expected {
+		t.Fatalf("incorrect unmarshalled name, expected %s, got %s", expected, actual)
+	}
+}
+
+func TestIsValidCluster(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"", false},
+		{"*", true},
+
+		{"elephant", true},
+		{"elephant:foo", true},
+		{"elephant:foo:bar", true},
+
+		{"system", true},
+		{"system:foo", true},
+		{"system:foo:bar", true},
+
+		// the plugin does not decide about segment length, the server does
+		{"elephant:b1234567890123456789012345678912", true},
+		{"elephant:test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
+		{"elephant:test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060:b1234567890123456789012345678912", true},
+
+		{"elephant:", false},
+		{":elephant", false},
+		{"elephant::foo", false},
+		{"elephant:föö:bär", false},
+		{"elephant:bar_bar", false},
+		{"elephant:a", false},
+		{"elephant:0a", false},
+		{"elephant:0bar", false},
+		{"elephant/bar", false},
+		{"elephant:bar-", false},
+		{"elephant:-bar", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.name).IsValid(); got != tt.valid {
+				t.Errorf("isValid(%q) = %v, want %v", tt.name, got, tt.valid)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Kubernetes 1.24 has renamed the field in a backwards-incomaptible
manner.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>