### PR TITLE
:bug: Single character lowercase names are valid

### DIFF
--- a/name.go
+++ b/name.go
@@ -23,7 +23,6 @@ import (
 	"strings"
 )
 
-
 // ClusterHeader set to "<lcluster>" on a request is an alternative to accessing the
 // cluster via /clusters/<lcluster>. With that the <lcluster> can be access via normal kube-like
 // /api and /apis endpoints.
@@ -136,7 +135,9 @@ func (n Name) HasPrefix(other Name) bool {
 	return strings.HasPrefix(n.value, other.value)
 }
 
-var lclusterRegExp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9](:[a-z][a-z0-9-]*[a-z0-9])*$`)
+const lclusterNameFmt string = "[a-z]([a-z0-9-]{0,61}[a-z0-9])?"
+
+var lclusterRegExp = regexp.MustCompile("^" + lclusterNameFmt + "(:" + lclusterNameFmt + ")*$")
 
 // IsValid returns true if the name is a Wildcard or a colon separated list of words where each word
 // starts with a lower-case letter and contains only lower-case letters, digits and hyphens.

--- a/name_test.go
+++ b/name_test.go
@@ -98,7 +98,6 @@ func TestIsValidCluster(t *testing.T) {
 		{"elephant::foo", false},
 		{"elephant:föö:bär", false},
 		{"elephant:bar_bar", false},
-		{"elephant:a", false},
 		{"elephant:0a", false},
 		{"elephant:0bar", false},
 		{"elephant/bar", false},

--- a/v2/name.go
+++ b/v2/name.go
@@ -138,7 +138,9 @@ func (n Name) HasPrefix(other Name) bool {
 	return strings.HasPrefix(n.value, other.value)
 }
 
-var lclusterRegExp = regexp.MustCompile(`^[a-z][a-z0-9-]*[a-z0-9](:[a-z][a-z0-9-]*[a-z0-9])*$`)
+const lclusterNameFmt string = "[a-z]([a-z0-9-]{0,61}[a-z0-9])?"
+
+var lclusterRegExp = regexp.MustCompile("^" + lclusterNameFmt + "(:" + lclusterNameFmt + ")*$")
 
 // IsValid returns true if the name is a Wildcard or a colon separated list of words where each word
 // starts with a lower-case letter and contains only lower-case letters, digits and hyphens.

--- a/v2/name_test.go
+++ b/v2/name_test.go
@@ -98,7 +98,6 @@ func TestIsValidCluster(t *testing.T) {
 		{"elephant::foo", false},
 		{"elephant:föö:bär", false},
 		{"elephant:bar_bar", false},
-		{"elephant:a", false},
 		{"elephant:0a", false},
 		{"elephant:0bar", false},
 		{"elephant/bar", false},


### PR DESCRIPTION
Partial fix for kcp-dev/kcp#2018

Compare:

```
$ kubectl apply -f - <<EOF
apiVersion: tenancy.kcp.dev/v1beta1
kind: Workspace
metadata:
  name: b
spec:
  type:
    name: universal
    path: root
EOF
workspace.tenancy.kcp.dev/b created
```

and:

```
$ kubectl apply -f - <<EOF
apiVersion: tenancy.kcp.dev/v1beta1
kind: Workspace
metadata:
  name: A
spec:
  type:
    name: organization
    path: root
EOF
The ClusterWorkspace "A" is invalid:
...
* metadata.name: Invalid value: "A": metadata.name in body should match '^[a-z]([a-z0-9-]{0,61}[a-z0-9])?$'
```

Adopt the helpful regexp above for our validation!