### PR TITLE
:sparkles: name: add some helpful constants

### DIFF
--- a/name.go
+++ b/name.go
@@ -46,6 +46,12 @@ const separator = ":"
 var (
 	// Wildcard is the name indicating cross-workspace requests.
 	Wildcard = New("*")
+
+	// None is the name indicating a cluster-unaware context.
+	None = New("")
+
+	// TODO is a value created by automated refactoring tools that should be replaced by a real Name.
+	TODO = None
 )
 
 // New returns a Name from a string.


### PR DESCRIPTION
When a codebase is refactoring to adopt logical clusters, two more constants are needed:

 - if the codebase wants to support single-cluster *or* multi-cluster contexts, they will want to pass logicalcluster.None to cluster-aware code in the former and some real logicalcluster.Name in the latter
 - when automated refactoring tools (or human refactors) are ongoing, it may not be entirely clear *which* cluster name to use; so a TODO constant akin to that from the ocntext package is added as well

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>
