### PR TITLE
:bug: Relax cluster name validation

### DIFF
--- a/name.go
+++ b/name.go
@@ -144,7 +144,7 @@ func (n Name) HasPrefix(other Name) bool {
 	return strings.HasPrefix(n.value, other.value)
 }
 
-const lclusterNameFmt string = "[a-z]([a-z0-9-]{0,61}[a-z0-9])?"
+const lclusterNameFmt string = "[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
 
 var lclusterRegExp = regexp.MustCompile("^" + lclusterNameFmt + "(:" + lclusterNameFmt + ")*$")
 

--- a/name_test.go
+++ b/name_test.go
@@ -87,6 +87,8 @@ func TestIsValidCluster(t *testing.T) {
 		{"system", true},
 		{"system:foo", true},
 		{"system:foo:bar", true},
+		{"elephant:0a", true},
+		{"elephant:0bar", true},
 
 		// the plugin does not decide about segment length, the server does
 		{"elephant:b1234567890123456789012345678912", true},
@@ -98,8 +100,6 @@ func TestIsValidCluster(t *testing.T) {
 		{"elephant::foo", false},
 		{"elephant:föö:bär", false},
 		{"elephant:bar_bar", false},
-		{"elephant:0a", false},
-		{"elephant:0bar", false},
 		{"elephant/bar", false},
 		{"elephant:bar-", false},
 		{"elephant:-bar", false},


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

Relax validation to match https://github.com/kcp-dev/kcp/pull/2341

## Related issue(s)

Fixes #
