### PR TITLE
🌱 introduce a new version (v3) of the logicalcluster package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/kcp-dev/logicalcluster/v2
+module github.com/kcp-dev/logicalcluster/v3
 
 go 1.18

--- a/name.go
+++ b/name.go
@@ -16,73 +16,50 @@ limitations under the License.
 
 package logicalcluster
 
-import (
-	"encoding/json"
-	"path"
-	"regexp"
-	"strings"
-)
-
-// ClusterHeader set to "<lcluster>" on a request is an alternative to accessing the
-// cluster via /clusters/<lcluster>. With that the <lcluster> can be access via normal kube-like
-// /api and /apis endpoints.
-const ClusterHeader = "X-Kubernetes-Cluster"
-
-// Name is the name of a logical cluster. A logical cluster is
-// 1. a (part of) etcd prefix to store objects in that cluster
-// 2. a (part of) a http path which serves a Kubernetes-cluster-like API with
-//    discovery, OpenAPI and the actual API groups.
-// 3. a value in metadata.clusterName in objects from cross-workspace list/watches,
-//    which is used to identify the logical cluster.
-//
-// A logical cluster is a colon separated list of words. In other words, it is
-// like a path, but with colons instead of slashes.
-type Name struct {
-	value string
-}
-
-const separator = ":"
+import "regexp"
 
 var (
-	// Wildcard is the name indicating cross-workspace requests.
-	Wildcard = New("*")
-
-	// None is the name indicating a cluster-unaware context.
-	None = New("")
-
-	// TODO is a value created by automated refactoring tools that should be replaced by a real Name.
-	TODO = None
+	clusterNameRegExp = regexp.MustCompile(clusterNameString)
 )
 
-// New returns a Name from a string.
-func New(value string) Name {
-	return Name{value}
+const (
+	clusterNameString string = "^[a-z0-9][a-z0-9-]{0,61}[a-z0-9]$"
+)
+
+// Name holds a value that uniquely identifies a logical cluster.
+// For instance, a logical cluster may have the name 33bab531.
+//
+// A logical cluster is a partition on the storage layer served as autonomous kube-like generic API endpoint.
+type Name string
+
+// Path creates a new Path object from the logical cluster name.
+// A convenience method for working with methods which accept a Path type.
+func (n Name) Path() Path {
+	return NewPath(string(n))
 }
 
-// NewValidated returns a Name from a string and whether it is a valid logical cluster.
-// A valid logical cluster returns true on IsValid().
-func NewValidated(value string) (Name, bool) {
-	n := Name{value}
-	return n, n.IsValid()
-}
-
-// Empty returns true if the logical cluster value is unset.
-func (n Name) Empty() bool {
-	return n.value == ""
-}
-
-// Path returns a path segment for the logical cluster to access its API.
-func (n Name) Path() string {
-	return path.Join("/clusters", n.value)
-}
-
-// String returns the string representation of the logical cluster name.
+// String returns string representation of the logical cluster name.
+// Satisfies the Stringer interface.
 func (n Name) String() string {
-	return n.value
+	return string(n)
 }
 
-// Object is a local interface representation of the Kubernetes metav1.Object, to avoid dependencies on
-// k8s.io/apimachinery.
+// IsValid returns true if the logical cluster name matches a defined format.
+// A convenience method that could be used for enforcing a well-known structure of a logical cluster name.
+//
+// As of today a valid value starts with a lower-case letter or digit
+// and contains only lower-case letters, digits and hyphens.
+func (n Name) IsValid() bool {
+	return clusterNameRegExp.MatchString(string(n))
+}
+
+// Empty returns true if the logical cluster name is unset.
+// It is a convenience method for checking against an empty value.
+func (n Name) Empty() bool {
+	return n == ""
+}
+
+// Object is a local interface representation of the Kubernetes metav1.Object, to avoid dependencies on k8s.io/apimachinery.
 type Object interface {
 	GetAnnotations() map[string]string
 }
@@ -90,66 +67,7 @@ type Object interface {
 // AnnotationKey is the name of the annotation key used to denote an object's logical cluster.
 const AnnotationKey = "kcp.dev/cluster"
 
-// From returns the logical cluster name for obj.
+// From returns the logical cluster name from the given object.
 func From(obj Object) Name {
-	return Name{obj.GetAnnotations()[AnnotationKey]}
-}
-
-// Parent returns the parent logical cluster name of the given logical cluster name.
-func (n Name) Parent() (Name, bool) {
-	parent, _ := n.Split()
-	return parent, parent.value != ""
-}
-
-// Split splits logical cluster immediately following the final colon,
-// separating it into a parent logical cluster and name component.
-// If there is no colon in path, Split returns an empty logical cluster name
-// and name set to path.
-func (n Name) Split() (parent Name, name string) {
-	i := strings.LastIndex(n.value, separator)
-	if i < 0 {
-		return Name{}, n.value
-	}
-	return Name{n.value[:i]}, n.value[i+1:]
-}
-
-// Base returns the last component of the logical cluster name.
-func (n Name) Base() string {
-	_, name := n.Split()
-	return name
-}
-
-// Join joins a parent logical cluster name and a name component.
-func (n Name) Join(name string) Name {
-	if n.value == "" {
-		return Name{name}
-	}
-	return Name{n.value + separator + name}
-}
-
-func (n Name) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&n.value)
-}
-
-func (n *Name) UnmarshalJSON(data []byte) error {
-	var s string
-	if err := json.Unmarshal(data, &s); err != nil {
-		return err
-	}
-	n.value = s
-	return nil
-}
-
-func (n Name) HasPrefix(other Name) bool {
-	return strings.HasPrefix(n.value, other.value)
-}
-
-const lclusterNameFmt string = "[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
-
-var lclusterRegExp = regexp.MustCompile("^" + lclusterNameFmt + "(:" + lclusterNameFmt + ")*$")
-
-// IsValid returns true if the name is a Wildcard or a colon separated list of words where each word
-// starts with a lower-case letter and contains only lower-case letters, digits and hyphens.
-func (n Name) IsValid() bool {
-	return n == Wildcard || lclusterRegExp.MatchString(n.value)
+	return Name(obj.GetAnnotations()[AnnotationKey])
 }

--- a/name_test.go
+++ b/name_test.go
@@ -16,87 +16,39 @@ limitations under the License.
 
 package logicalcluster
 
-import (
-	"encoding/json"
-	"testing"
-)
+import "testing"
 
-func TestName_Split(t *testing.T) {
-	tests := []struct {
-		cn     Name
-		parent Name
-		name   string
-	}{
-		{New(""), New(""), ""},
-		{New("foo"), New(""), "foo"},
-		{New("foo:bar"), New("foo"), "bar"},
-		{New("foo:bar:baz"), New("foo:bar"), "baz"},
-		{New("foo::baz"), New("foo:"), "baz"},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			gotParent, gotName := tt.cn.Split()
-			if gotParent != tt.parent {
-				t.Errorf("Split() gotParent = %v, want %v", gotParent, tt.parent)
-			}
-			if gotName != tt.name {
-				t.Errorf("Split() gotName = %v, want %v", gotName, tt.name)
-			}
-		})
-	}
-}
-
-func TestJSON(t *testing.T) {
-	type container struct {
-		Name Name `json:"name"`
-	}
-
-	initial := container{
-		Name: New("foo:bar"),
-	}
-
-	raw, err := json.Marshal(initial)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if actual, expected := string(raw), `{"name":"foo:bar"}`; actual != expected {
-		t.Fatalf("incorrect marshalled bytes, expected %s, got %s", expected, actual)
-	}
-
-	var final container
-	if err := json.Unmarshal(raw, &final); err != nil {
-		t.Fatal(err)
-	}
-	if actual, expected := initial.Name, final.Name; actual != expected {
-		t.Fatalf("incorrect unmarshalled name, expected %s, got %s", expected, actual)
-	}
-}
-
-func TestIsValidCluster(t *testing.T) {
+func TestIsValidName(t *testing.T) {
 	tests := []struct {
 		name  string
 		valid bool
 	}{
 		{"", false},
-		{"*", true},
+		{"*", false},
 
 		{"elephant", true},
-		{"elephant:foo", true},
-		{"elephant:foo:bar", true},
+		{"elephant:foo", false},
+		{"elephant:foo:bar", false},
 
 		{"system", true},
-		{"system:foo", true},
-		{"system:foo:bar", true},
-		{"elephant:0a", true},
-		{"elephant:0bar", true},
+		{"system:foo", false},
+		{"system-foo", true},
+		{"system:foo:bar", false},
+		{"system-foo-bar", true},
+		{"elephant:0a", false},
+		{"elephant-0a", true},
+		{"elephant:0bar", false},
+		{"elephant-0bar", true},
 
-		// the plugin does not decide about segment length, the server does
-		{"elephant:b1234567890123456789012345678912", true},
-		{"elephant:test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
-		{"elephant:test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060:b1234567890123456789012345678912", true},
+		{"elephant:b1234567890123456789012345678912", false},
+		{"elephant:test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", false},
+		{"elephant:test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060:b1234567890123456789012345678912", false},
+		{"elephant-test-8827a131-f796-4473-8904-a0fa527696eb-b1234567890123456789012345678912", false},
 
 		{"elephant:", false},
 		{":elephant", false},
+		{"-elephant", false},
+		{"elephant-", false},
 		{"elephant::foo", false},
 		{"elephant:föö:bär", false},
 		{"elephant:bar_bar", false},
@@ -106,7 +58,7 @@ func TestIsValidCluster(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := New(tt.name).IsValid(); got != tt.valid {
+			if got := Name(tt.name).IsValid(); got != tt.valid {
 				t.Errorf("isValid(%q) = %v, want %v", tt.name, got, tt.valid)
 			}
 		})

--- a/path.go
+++ b/path.go
@@ -1,0 +1,167 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"encoding/json"
+	"path"
+	"regexp"
+	"strings"
+)
+
+var (
+	// Wildcard is the path indicating a requests that spans many logical clusters.
+	Wildcard = Path{value: "*"}
+
+	// None represents an unset path.
+	None = Path{}
+
+	// TODO is a value created by automated refactoring tools that should be replaced by a real path.
+	TODO = None
+)
+
+const (
+	separator = ":"
+)
+
+// Path represents a colon separated list of words describing a path in a logical cluster hierarchy,
+// like a file path in a file-system.
+//
+// For instance, in the following hierarchy:
+//
+// root/                    (62208dab)
+// ├── accounting           (c8a942c5)
+// │   └── us-west          (33bab531)
+// │       └── invoices     (f5865fce)
+// └── management           (e7e08986)
+//     └── us-west-invoices (f5865fce)
+//
+// the following would all be valid paths:
+//
+//   - root:accounting:us-west:invoices
+//   - 62208dab:accounting:us-west:invoices
+//   - c8a942c5:us-west:invoices
+//   - 33bab531:invoices
+//   - f5865fce
+//   - root:management:us-west-invoices
+//   - 62208dab:management:us-west-invoices
+//   - e7e08986:us-west-invoices
+type Path struct {
+	value string
+}
+
+// NewPath returns a new Path.
+func NewPath(value string) Path {
+	return Path{value}
+}
+
+// NewValidatedPath returns a Path and whether it is valid.
+func NewValidatedPath(value string) (Path, bool) {
+	p := Path{value}
+	return p, p.IsValid()
+}
+
+// Empty returns true if the stored path is unset.
+// It is a convenience method for checking against an empty value.
+func (p Path) Empty() bool {
+	return p.value == ""
+}
+
+// Name return a new Name object from the stored path and whether it can be created.
+// A convenience method for working with methods which accept a Name type.
+func (p Path) Name() (Name, bool) {
+	if _, hasParent := p.Parent(); hasParent {
+		return "", false
+	}
+	return Name(p.value), true
+}
+
+// RequestPath returns a URL path segment used to access API for the stored path.
+func (p Path) RequestPath() string {
+	return path.Join("/clusters", p.value)
+}
+
+// String returns string representation of the stored value.
+// Satisfies the Stringer interface.
+func (p Path) String() string {
+	return p.value
+}
+
+// Parent returns a new path with all but the last element of the stored path.
+func (p Path) Parent() (Path, bool) {
+	parent, _ := p.Split()
+	return parent, parent.value != ""
+}
+
+// Split splits the path immediately following the final colon,
+// separating it into a new path and a logical cluster name component.
+// If there is no colon in the path,
+// Split returns an empty path and a name set to the path.
+func (p Path) Split() (parent Path, name string) {
+	i := strings.LastIndex(p.value, separator)
+	if i < 0 {
+		return Path{}, p.value
+	}
+	return Path{p.value[:i]}, p.value[i+1:]
+}
+
+// Base returns the last element of the path.
+func (p Path) Base() string {
+	_, name := p.Split()
+	return name
+}
+
+// Join returns a new path by adding the given path segment
+// into already existing path and separating it with a colon.
+func (p Path) Join(name string) Path {
+	if p.value == "" {
+		return Path{name}
+	}
+	return Path{p.value + separator + name}
+}
+
+// MarshalJSON satisfies the Marshaler interface
+// for encoding the path into JSON.
+func (p Path) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&p.value)
+}
+
+// UnmarshalJSON satisfies the Unmarshaler interface implemented by types
+// for decoding a JSON encoded path.
+func (p *Path) UnmarshalJSON(data []byte) error {
+	var s string
+	if err := json.Unmarshal(data, &s); err != nil {
+		return err
+	}
+	p.value = s
+	return nil
+}
+
+// HasPrefix tests whether the path begins with the other path.
+func (p Path) HasPrefix(other Path) bool {
+	return strings.HasPrefix(p.value, other.value)
+}
+
+const lclusterNameFmt string = "[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
+
+var lclusterRegExp = regexp.MustCompile("^" + lclusterNameFmt + "(:" + lclusterNameFmt + ")*$")
+
+// IsValid returns true if the path is a Wildcard or a colon separated list of words where each word
+// starts with a lower-case letter and contains only lower-case letters, digits and hyphens.
+func (p Path) IsValid() bool {
+	return p == Wildcard || lclusterRegExp.MatchString(p.value)
+}

--- a/path_test.go
+++ b/path_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2022 The KCP Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logicalcluster
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestPath_Split(t *testing.T) {
+	tests := []struct {
+		cn     Path
+		parent Path
+		name   string
+	}{
+		{NewPath(""), NewPath(""), ""},
+		{NewPath("foo"), NewPath(""), "foo"},
+		{NewPath("foo:bar"), NewPath("foo"), "bar"},
+		{NewPath("foo:bar:baz"), NewPath("foo:bar"), "baz"},
+		{NewPath("foo::baz"), NewPath("foo:"), "baz"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotParent, gotName := tt.cn.Split()
+			if gotParent != tt.parent {
+				t.Errorf("Split() gotParent = %v, want %v", gotParent, tt.parent)
+			}
+			if gotName != tt.name {
+				t.Errorf("Split() gotName = %v, want %v", gotName, tt.name)
+			}
+		})
+	}
+}
+
+func TestIsValidPath(t *testing.T) {
+	tests := []struct {
+		name  string
+		valid bool
+	}{
+		{"", false},
+		{"*", true},
+
+		{"elephant", true},
+		{"elephant:foo", true},
+		{"elephant:foo:bar", true},
+
+		{"system", true},
+		{"system:foo", true},
+		{"system:foo:bar", true},
+		{"elephant:0a", true},
+		{"elephant:0bar", true},
+
+		// the plugin does not decide about segment length, the server does
+		{"elephant:b1234567890123456789012345678912", true},
+		{"elephant:test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
+		{"elephant:test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060:b1234567890123456789012345678912", true},
+
+		{"elephant:", false},
+		{":elephant", false},
+		{"elephant::foo", false},
+		{"elephant:föö:bär", false},
+		{"elephant:bar_bar", false},
+		{"elephant/bar", false},
+		{"elephant:bar-", false},
+		{"elephant:-bar", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NewPath(tt.name).IsValid(); got != tt.valid {
+				t.Errorf("isValid(%q) = %v, want %v", tt.name, got, tt.valid)
+			}
+		})
+	}
+}
+
+func TestJSON(t *testing.T) {
+	type container struct {
+		ClusterPath Path `json:"clusterPath"`
+	}
+
+	initial := container{
+		ClusterPath: NewPath("foo:bar"),
+	}
+
+	raw, err := json.Marshal(initial)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if actual, expected := string(raw), `{"clusterPath":"foo:bar"}`; actual != expected {
+		t.Fatalf("incorrect marshalled bytes, expected %s, got %s", expected, actual)
+	}
+
+	var final container
+	if err := json.Unmarshal(raw, &final); err != nil {
+		t.Fatal(err)
+	}
+	if actual, expected := initial.ClusterPath, final.ClusterPath; actual != expected {
+		t.Fatalf("incorrect unmarshalled name, expected %s, got %s", expected, actual)
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR introduces a new version (v3) of the logicalcluster package.

The new version splits the old type into a new `Name` type (holds a value that uniquely identifies a logical cluster).

And a new `Path` type which represents a colon separated list of words describing a path in a logical cluster hierarchy,
like a file path in a file-system.

```
// For instance, in the following hierarchy:
//
// root/                    (62208dab)
// ├── accounting           (c8a942c5)
// │   └── us-west          (33bab531)
// │       └── invoices     (f5865fce)
// └── management           (e7e08986)
//     └── us-west-invoices (f5865fce)
//
// the following would all be valid paths:
//
//   - root:accounting:us-west:invoices
//   - 62208dab:accounting:us-west:invoices
//   - c8a942c5:us-west:invoices
//   - 33bab531:invoices
//   - f5865fce
//   - root:management:us-west-invoices
//   - 62208dab:management:us-west-invoices
//   - e7e08986:us-west-invoices
```

## Related issue(s)

Fixes #
