### PR TITLE
🌱 special case for the system prefix

### DIFF
--- a/name.go
+++ b/name.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package logicalcluster
 
-import "regexp"
+import (
+	"regexp"
+	"strings"
+)
 
 var (
 	clusterNameRegExp = regexp.MustCompile(clusterNameString)
@@ -50,7 +53,7 @@ func (n Name) String() string {
 // As of today a valid value starts with a lower-case letter or digit
 // and contains only lower-case letters, digits and hyphens.
 func (n Name) IsValid() bool {
-	return clusterNameRegExp.MatchString(string(n))
+	return strings.HasPrefix(string(n), "system:") || clusterNameRegExp.MatchString(string(n))
 }
 
 // Empty returns true if the logical cluster name is unset.

--- a/name_test.go
+++ b/name_test.go
@@ -31,10 +31,11 @@ func TestIsValidName(t *testing.T) {
 		{"elephant:foo:bar", false},
 
 		{"system", true},
-		{"system:foo", false},
+		{"system:foo", true},
 		{"system-foo", true},
-		{"system:foo:bar", false},
+		{"system:foo:bar", true},
 		{"system-foo-bar", true},
+
 		{"elephant:0a", false},
 		{"elephant-0a", true},
 		{"elephant:0bar", false},

--- a/path.go
+++ b/path.go
@@ -84,6 +84,9 @@ func (p Path) Empty() bool {
 // Name return a new Name object from the stored path and whether it can be created.
 // A convenience method for working with methods which accept a Name type.
 func (p Path) Name() (Name, bool) {
+	if strings.HasPrefix(p.value, "system:") {
+		return Name(p.value), true
+	}
 	if _, hasParent := p.Parent(); hasParent {
 		return "", false
 	}

--- a/path_test.go
+++ b/path_test.go
@@ -61,10 +61,10 @@ func TestIsValidPath(t *testing.T) {
 		{"system", true},
 		{"system:foo", true},
 		{"system:foo:bar", true},
+
 		{"elephant:0a", true},
 		{"elephant:0bar", true},
 
-		// the plugin does not decide about segment length, the server does
 		{"elephant:b1234567890123456789012345678912", true},
 		{"elephant:test-8827a131-f796-4473-8904-a0fa527696eb:b1234567890123456789012345678912", true},
 		{"elephant:test-too-long-org-0020-4473-0030-a0fa-0040-5276-0050-sdg2-0060:b1234567890123456789012345678912", true},
@@ -110,5 +110,28 @@ func TestJSON(t *testing.T) {
 	}
 	if actual, expected := initial.ClusterPath, final.ClusterPath; actual != expected {
 		t.Fatalf("incorrect unmarshalled name, expected %s, got %s", expected, actual)
+	}
+}
+
+func TestPath_Name(t *testing.T) {
+	tests := []struct {
+		path             Path
+		expectedName     Name
+		expectToFindName bool
+	}{
+		{NewPath("elephant:b1234567890123456789012345678912"), Name(""), false},
+		{NewPath("elephant"), Name("elephant"), true},
+		{NewPath("system:crds"), Name("system:crds"), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.path.String(), func(t *testing.T) {
+			gotName, hasName := tt.path.Name()
+			if hasName != tt.expectToFindName {
+				t.Fatalf("path = %s, hasName = %v, expected to find a name = %v", tt.path, hasName, tt.expectToFindName)
+			}
+			if gotName != tt.expectedName {
+				t.Fatalf("Name() gotName = %v, want %v", gotName, tt.expectedName)
+			}
+		})
 	}
 }


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
This PR allows us to use `sytem:crds` as a logical cluster name.

In general, the system prefix is always valid and represents a logical cluster name (not a path).

## Related issue(s)

Fixes #
