### PR TITLE
🌱 expose path.Equal method for comparing equality with other paths

### DIFF
--- a/path.go
+++ b/path.go
@@ -115,6 +115,9 @@ func (p Path) Parent() (Path, bool) {
 // If there is no colon in the path,
 // Split returns an empty path and a name set to the path.
 func (p Path) Split() (parent Path, name string) {
+	if strings.HasPrefix(p.value, "system:") {
+		return Path{p.value}, ""
+	}
 	i := strings.LastIndex(p.value, separator)
 	if i < 0 {
 		return Path{}, p.value

--- a/path.go
+++ b/path.go
@@ -162,6 +162,11 @@ func (p Path) HasPrefix(other Path) bool {
 	return strings.HasPrefix(p.value, other.value)
 }
 
+// Equal checks if the path is the same as the other path.
+func (p Path) Equal(other Path) bool {
+	return p.value == other.value
+}
+
 const lclusterNameFmt string = "[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?"
 
 var lclusterRegExp = regexp.MustCompile("^" + lclusterNameFmt + "(:" + lclusterNameFmt + ")*$")

--- a/path_test.go
+++ b/path_test.go
@@ -32,6 +32,8 @@ func TestPath_Split(t *testing.T) {
 		{NewPath("foo:bar"), NewPath("foo"), "bar"},
 		{NewPath("foo:bar:baz"), NewPath("foo:bar"), "baz"},
 		{NewPath("foo::baz"), NewPath("foo:"), "baz"},
+
+		{NewPath("system:crds"), NewPath("system:crds"), ""},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary
 - do not split a path with the `system:` prefix
 - expose `path.Equal` method for comparing equality with other paths (i.e. used by `cmp` pkg)
## Related issue(s)

Fixes #
