### PR TITLE
:seedling: replace kcp.dev by kcp.io

### DIFF
--- a/name.go
+++ b/name.go
@@ -68,7 +68,7 @@ type Object interface {
 }
 
 // AnnotationKey is the name of the annotation key used to denote an object's logical cluster.
-const AnnotationKey = "kcp.dev/cluster"
+const AnnotationKey = "kcp.io/cluster"
 
 // From returns the logical cluster name from the given object.
 func From(obj Object) Name {


### PR DESCRIPTION
## Summary

This PR replaces the annotation key for logical cluster from "kcp.dev/cluster" to "kcp.io/cluster".

## Related issue(s)

It is a follow-up of https://github.com/kcp-dev/kcp/pull/2517

Signed-off-by: Frederic Giloux <fgiloux@redhat.com>

