### PR TITLE
:seedling: Add .prow.yaml, migrate to kcp-prow

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,0 @@
-build_root_image:
-  namespace: ci
-  name: kcp-dev-build-root
-  tag: "1.18"

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -7,7 +7,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-6
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-1
           command:
             - make
             - verify-imports
@@ -21,7 +21,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-6
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-1
           command:
             - make
             - lint
@@ -34,7 +34,7 @@ presubmits:
       preset-goproxy: "true"
     spec:
       containers:
-        - image: quay.io/kubermatic/build:go-1.20-node-18-6
+        - image: ghcr.io/kcp-dev/infra/build:1.19.9-1
           command:
             - make
             - test

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,8 +1,24 @@
 presubmits:
+  - name: pull-logicalcluster-verify
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/logicalcluster.git"
+    labels:
+      preset-goproxy: "true"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.20-node-18-6
+          command:
+            - make
+            - verify-imports
+            - verify-boilerplate
+
   - name: pull-logicalcluster-lint
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kcp-dev/logicalcluster.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.20-node-18-6
@@ -14,6 +30,8 @@ presubmits:
     always_run: true
     decorate: true
     clone_uri: "ssh://git@github.com/kcp-dev/logicalcluster.git"
+    labels:
+      preset-goproxy: "true"
     spec:
       containers:
         - image: quay.io/kubermatic/build:go-1.20-node-18-6

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -9,3 +9,14 @@ presubmits:
           command:
             - make
             - lint
+
+  - name: pull-logicalcluster-test
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/logicalcluster.git"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.20-node-18-6
+          command:
+            - make
+            - test

--- a/.prow.yaml
+++ b/.prow.yaml
@@ -1,0 +1,11 @@
+presubmits:
+  - name: pull-logicalcluster-lint
+    always_run: true
+    decorate: true
+    clone_uri: "ssh://git@github.com/kcp-dev/logicalcluster.git"
+    spec:
+      containers:
+        - image: quay.io/kubermatic/build:go-1.20-node-18-6
+          command:
+            - make
+            - lint

--- a/Makefile
+++ b/Makefile
@@ -32,19 +32,19 @@ $(TOOLS_DIR)/verify_boilerplate.py:
 	chmod +x $(TOOLS_DIR)/verify_boilerplate.py
 
 .PHONY: verify-boilerplate
-verify-boilerplate: $(TOOLS_DIR)/verify_boilerplate.py
+verify-boilerplate: $(TOOLS_DIR)/verify_boilerplate.py ## Verify that all files have their proper boilerplate comments.
 	$(TOOLS_DIR)/verify_boilerplate.py --boilerplate-dir=hack/boilerplate
 
 .PHONY: verify-imports
-verify-imports:
+verify-imports: ## Ensure no forbidden Go import statements exist.
 	hack/reject-k8s-imports.sh
 
 .PHONY: lint
-lint: $(GOLANGCI_LINT)
+lint: $(GOLANGCI_LINT) ## Run golangci-lint.
 	$(GOLANGCI_LINT) run --timeout=10m ./...
 
 .PHONY: test
-test:
+test: ## Run Go unit tests.
 	go test ./...
 
 .PHONY: help

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ GO_INSTALL = ./hack/go-install.sh
 TOOLS_DIR=hack/tools
 GOBIN_DIR := $(abspath $(TOOLS_DIR))
 
-GOLANGCI_LINT_VER := v1.44.2
+GOLANGCI_LINT_VER := v1.48.0
 GOLANGCI_LINT_BIN := golangci-lint
 GOLANGCI_LINT := $(GOBIN_DIR)/$(GOLANGCI_LINT_BIN)-$(GOLANGCI_LINT_VER)
 


### PR DESCRIPTION
## Summary
This PR is the first step towards migrating this repository from Openshift's CI to kcp's own Prow. This PR adds a `.prow.yaml` with 3 new jobs, mimicing the ci/* jobs:

* `pull-logicalcluster-verify` runs the two verify make targets
* `pull-logicalcluster-test` runs `make test`
* `pull-logicalcluster-lint` runs `make lint`

I presume because Openshift's CI is still configured for this repo (see https://github.com/openshift/release/pull/39639), the kcp-prow tide doesn't show up here yet, but they can be observed on https://public-prow.kcp.k8c.io/?repo=kcp-dev%2Flogicalcluster

golangci-lint had to be bumped to be compatible with the new Docker image used (see https://github.com/golangci/golangci-lint-action/issues/434). I chose to bump as little as possible, just to make it compatible and not introduce new linting issues.

Fixes kcp-dev/infra#33

**Release Notes:**
```release-note
Migrated to a new Prow instance exclusive for kcp-dev
```