### PR TITLE
:bug: HasPrefix: properly separate by :

### DIFF
--- a/path.go
+++ b/path.go
@@ -159,7 +159,14 @@ func (p *Path) UnmarshalJSON(data []byte) error {
 
 // HasPrefix tests whether the path begins with the other path.
 func (p Path) HasPrefix(other Path) bool {
-	return strings.HasPrefix(p.value, other.value)
+	if p == other || other.Empty() {
+		return true
+	}
+	if strings.HasSuffix(other.String(), separator) {
+		// this is not a valid path, but we should have a defined behaviour
+		return strings.HasPrefix(p.value, other.value)
+	}
+	return strings.HasPrefix(p.value, other.value+separator)
 }
 
 // Equal checks if the path is the same as the other path.

--- a/path_test.go
+++ b/path_test.go
@@ -137,3 +137,28 @@ func TestPath_Name(t *testing.T) {
 		})
 	}
 }
+
+func TestPathHasPrefix(t *testing.T) {
+	tests := []struct {
+		name  string
+		path  Path
+		other Path
+		want  bool
+	}{
+		{"empty both", NewPath(""), NewPath(""), true},
+		{"empty other", NewPath("foo"), NewPath(""), true},
+		{"empty path", NewPath(""), NewPath("foo"), false},
+		{"equal", NewPath("foo"), NewPath("foo"), true},
+		{"prefix", NewPath("foo:bar"), NewPath("foo"), true},
+		{"string prefix only", NewPath("foooo:bar"), NewPath("foo"), false},
+		{"not prefix", NewPath("foo"), NewPath("foo:bar"), false},
+		{"other ending in :", NewPath("foo:bar"), NewPath("foo:"), true}, // "foo:" is not a valid path, but we should have a defined behaviour
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.path.HasPrefix(tt.other); got != tt.want {
+				t.Errorf("HasPrefix() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thanks for creating a pull request!

If this is your first time, please make sure to review CONTRIBUTING.MD.

Please copy the appropriate `:text:` or icon to the beginning of your PR title:

:sparkles: ✨ feature
:bug: 🐛 bug fix
:book: 📖 docs
:memo: 📝 proposal
:warning: ⚠️ breaking change
:seedling: 🌱 other/misc
:question: ❓ requires manual review/categorization

-->
## Summary

`NewPath("foooo:bar").HasPrefix("foo")` should not return true.

## Release Notes

<!--
Please add a release note using the following format:

```release-note
<description of change>
```
-->

```release-note
Fix `HasPrefix` to compare up to a colon, not arbitrary string prefix.
```